### PR TITLE
Updated for chunking based on sections

### DIFF
--- a/src/backend/fastapi_app/services/pdf_parser/pdf_parser.py
+++ b/src/backend/fastapi_app/services/pdf_parser/pdf_parser.py
@@ -74,8 +74,9 @@ def md_to_dict(md_text: str, include_ref=False) -> List[Dict[str, str]]:
             # terminate when the header name starts with reference
             if element_str.upper().startswith("REFERENCE") and not include_ref:
                 break
+            valid_header = is_valid_header(element_str, current_title)
             # check if the current title is a valid section header
-            if is_valid_header(element_str, current_title): 
+            if valid_header: 
                 if current_title:
                     section_list.append({
                         "header": current_title,
@@ -83,8 +84,12 @@ def md_to_dict(md_text: str, include_ref=False) -> List[Dict[str, str]]:
                     })
                 current_title = element_str
                 current_text = []
+            elif not valid_header and current_title: 
+                current_text.append(element_str)
+                current_text.append('\n') # added for separating subsection/subsubsection name and paragraph
         # check for narrative text (paragraphs/sentences) 
-        elif element.category in ["NarrativeText"] and current_title:
+        # https://docs.unstructured.io/open-source/concepts/document-elements
+        elif element.category in ["NarrativeText", "UncategorizedText", "ListItem"] and current_title:
             current_text.append(element_str)
     if current_title:
         section_list.append({

--- a/src/backend/fastapi_app/services/pdf_parser/section_checker.py
+++ b/src/backend/fastapi_app/services/pdf_parser/section_checker.py
@@ -1,8 +1,8 @@
 import re
 from typing import Optional
 
-NUMERAL_HEADER_REGEX = r"^\d+[\.\s]+[A-Za-z0-9\s?]+" # Starts with a number followed by alphanum or ./?/space/
-ROMAN_NUM_HEADER_REGEX = r"^(X{0,2}(IX|IV|V?I{0,3}))\b[\s.]+[A-Za-z0-9]" # Roman numerals up to 20
+NUMERAL_HEADER_REGEX = r"^\d+(\.| )?([A-Z][a-z]+)" # Starts with a number (int not float) e.g. 1. <Title>, 1 <Title>, 1<Title>...
+ROMAN_NUM_HEADER_REGEX = r"^(X{0,2}(IX|IV|V?I{0,3}))\b[\s.]+[A-Za-z0-9]+" # Roman numerals up to 20
 HEADER_REGEX = re.compile(f"{NUMERAL_HEADER_REGEX}|{ROMAN_NUM_HEADER_REGEX}")
 
 def is_valid_header(new_header: str, prev_header: str) -> bool:


### PR DESCRIPTION
**Minor updates:** 

- Matching **section titles only**, excluding subsection and subsubsection titles. All content from subsections and subsubsections will be grouped under the corresponding section.
- Including texts classified as "UncategorizedText" or "ListItem" (incorrectly classified when parsing) as section content. 